### PR TITLE
Fix missing leading zeros in decimals

### DIFF
--- a/tests/test_fraction.py
+++ b/tests/test_fraction.py
@@ -69,6 +69,10 @@ def test_comparable_with_self(
         (Fraction(1, 3), "0.̇3"),
         (Fraction(2, 3), "0.̇6"),
         (Fraction(9, 11), "0.̇8̇1"),
+        (Fraction(3, 10), "0.3"),
+        (Fraction(3, 100), "0.03"),
+        (Fraction(3, 1000), "0.003"),
+        (Fraction(303, 10000), "0.0303"),
     ],
 )
 def test_decimal(f: Fraction, expect: str) -> None:

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -1,6 +1,8 @@
+from io import StringIO
+
 from pytest import mark
 
-from vinculum import greatest_common_divisor
+from vinculum import greatest_common_divisor, int_to_buffer
 
 
 @mark.parametrize(
@@ -13,3 +15,9 @@ from vinculum import greatest_common_divisor
 )
 def test_greatest_common_divisor(a: int, b: int, expect: int) -> None:
     assert greatest_common_divisor(a, b) == expect
+
+
+def test_int_to_buffer__leading() -> None:
+    buffer = StringIO()
+    int_to_buffer(300, buffer, leading_zeros=3)
+    assert buffer.getvalue() == "000300"

--- a/vinculum/fraction.py
+++ b/vinculum/fraction.py
@@ -182,9 +182,11 @@ class Fraction:
         recursion_track: Optional[List[int]] = [] if recursion else None
         remainder = (abs(self._numerator) % self._denominator) * 10
 
-        fractional = 0
-        recurring_count = 0
+        added_non_zero = False
         decimal_places = 0
+        fractional = 0
+        leading_zeros = 0
+        recurring_count = 0
 
         while True:
             i = remainder // self._denominator
@@ -197,6 +199,12 @@ class Fraction:
 
             fractional *= 10
             fractional += i
+
+            if i > 0:
+                added_non_zero = True
+            elif not added_non_zero:
+                leading_zeros += 1
+
             decimal_places += 1
 
             if remainder == 0 or decimal_places >= max_dp:
@@ -208,6 +216,7 @@ class Fraction:
         int_to_buffer(
             fractional,
             result,
+            leading_zeros=leading_zeros,
             recurring_count=recurring_count,
             recurring_prefix=recurring_prefix,
         )

--- a/vinculum/math.py
+++ b/vinculum/math.py
@@ -26,6 +26,7 @@ def greatest_common_divisor(a: int, b: int) -> int:
 def int_to_buffer(
     number: int,
     buffer: StringIO,
+    leading_zeros: int = 0,
     recurring_count: int = 0,
     recurring_prefix: Optional[str] = "\u0307",
 ) -> None:
@@ -33,6 +34,9 @@ def int_to_buffer(
     Writes the integer `number` to string `buffer`.
 
     Avoids CVE-2020-10735: https://github.com/python/cpython/issues/95778
+
+    `leading_zeros` describes the number of leading zeros to prefix before
+    `number`.
 
     `recurring_count` describes the count of least-significant digits that
     should be formatted as recurring.
@@ -47,17 +51,20 @@ def int_to_buffer(
 
     wip: List[str] = []
 
-    if number == 0:
-        wip.append("0")
-    else:
-        e = 0
-        while (10**e) <= number:
-            digit = int(number // 10**e) % 10
-            wip.append(str(digit))
-            e += 1
+    min_leading_zeros = 1 if number == 0 else leading_zeros
+    leading_zeros = max(leading_zeros, min_leading_zeros)
+
+    e = 0
+    while (10**e) <= number:
+        digit = int(number // 10**e) % 10
+        wip.append(str(digit))
+        e += 1
 
     if not positive:
         buffer.write("-")
+
+    for _ in range(leading_zeros):
+        buffer.write("0")
 
     recur_from = len(wip) - recurring_count
 


### PR DESCRIPTION
This fixes leading zeros being omitted from `decimal` output.

Previously, `Fraction(3, 100).decimal()` would return `0.3`. The function now returns `0.03`.